### PR TITLE
feat: add user endpoints with CRUD operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,12 @@ jobs:
         
         echo "Testing if test files exist..."
         ls -la src/__tests__/
-        
+    
+    - name: Run database migrations
+      run: |
+        echo "Running database migrations..."
+        NODE_ENV=test npx sequelize-cli db:migrate
+        echo "Migrations completed!"
         
     - name: Run all tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,12 @@ jobs:
         echo "Testing if test files exist..."
         ls -la src/__tests__/
     
+    - name: Create test database
+      run: |
+        echo "Creating test database..."
+        PGPASSWORD=testpassword psql -h localhost -U testuser -d testdb -c "CREATE DATABASE testdb_test;" || echo "Database may already exist"
+        echo "Test database ready!"
+    
     - name: Run database migrations
       run: |
         echo "Running database migrations..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,11 @@ jobs:
     - name: Create test database
       run: |
         echo "Creating test database..."
-        PGPASSWORD=testpassword psql -h localhost -U testuser -d testdb -c "CREATE DATABASE testdb_test;" || echo "Database may already exist"
+        PGPASSWORD=$POSTGRES_PASSWORD psql \
+          -h localhost \
+          -U $POSTGRES_USER \
+          -d $POSTGRES_DB \
+          -c "CREATE DATABASE ${POSTGRES_DB}_test;" || echo "Database may already exist"
         echo "Test database ready!"
     
     - name: Run database migrations

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "minio": "^8.0.6",
         "multer": "^2.0.2",
@@ -2957,6 +2958,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/express-validator/node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
+    "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "minio": "^8.0.6",
     "multer": "^2.0.2",
@@ -29,8 +30,8 @@
   "devDependencies": {
     "jest": "^30.2.0",
     "nodemon": "^3.1.10",
-    "socket.io-client": "^4.8.1",
     "sequelize-cli": "^6.6.3",
+    "socket.io-client": "^4.8.1",
     "supertest": "^7.1.4"
   },
   "overrides": {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import { initializeDatabase, initializeStorage } from './src/services/connection
 import healthRoutes from './src/routes/health.js';
 import { setupSocket } from './src/socket/socket.js';
 import issueRoutes from './src/routes/issues.js';
+import userRoutes from './src/routes/users.js';
 
 const app = express();
 const server = http.createServer(app);
@@ -21,6 +22,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use('/api/health', healthRoutes);
 
 app.use('/api/v1/issues', issueRoutes);
+app.use('/api/v1/users', userRoutes);
 
 // Basic route
 app.get('/api/', (req, res) => {

--- a/src/__tests__/users.test.js
+++ b/src/__tests__/users.test.js
@@ -1,0 +1,343 @@
+import request from 'supertest';
+import express from 'express';
+import { getSequelizeInstance } from '../services/connectionService.js';
+import userRoutes from '../routes/users.js';
+import User from '../models/user.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/users', userRoutes);
+
+let sequelize;
+
+beforeAll(async () => {
+  sequelize = getSequelizeInstance();
+  await sequelize.sync({ force: true }); // Reset database before tests
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+describe('User Endpoints - Technicians', () => {
+  let technicianId;
+
+  describe('POST /api/v1/users/technicians', () => {
+    it('should create a new technician with valid data', async () => {
+      const res = await request(app).post('/api/v1/users/technicians').send({
+        name: 'John Doe',
+        email: 'john.tech@test.com',
+        phone: '0771234567'
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('id');
+      expect(res.body.data.name).toBe('John Doe');
+      expect(res.body.data.email).toBe('john.tech@test.com');
+      expect(res.body.data.role).toBe('technician');
+      expect(res.body.data).not.toHaveProperty('password');
+
+      technicianId = res.body.data.id;
+    });
+
+    it('should reject technician with duplicate email', async () => {
+      const res = await request(app).post('/api/v1/users/technicians').send({
+        name: 'Jane Doe',
+        email: 'john.tech@test.com', // Same email as above
+        phone: '0772345678'
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('Email already exists');
+    });
+
+    it('should reject technician with invalid email format', async () => {
+      const res = await request(app).post('/api/v1/users/technicians').send({
+        name: 'Invalid Email',
+        email: 'not-an-email',
+        phone: '0773456789'
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should reject technician with missing name', async () => {
+      const res = await request(app).post('/api/v1/users/technicians').send({
+        email: 'noname@test.com',
+        phone: '0774567890'
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should reject technician with short phone number', async () => {
+      const res = await request(app).post('/api/v1/users/technicians').send({
+        name: 'Short Phone',
+        email: 'shortphone@test.com',
+        phone: '123' // Too short
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('GET /api/v1/users/technicians', () => {
+    it('should get all technicians', async () => {
+      const res = await request(app).get('/api/v1/users/technicians');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body).toHaveProperty('count');
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+      expect(res.body.data[0].role).toBe('technician');
+    });
+  });
+
+  describe('GET /api/v1/users/technicians/:id', () => {
+    it('should get technician by valid ID', async () => {
+      const res = await request(app).get(`/api/v1/users/technicians/${technicianId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.id).toBe(technicianId);
+      expect(res.body.data.role).toBe('technician');
+    });
+
+    it('should return 404 for non-existent technician ID', async () => {
+      const res = await request(app).get('/api/v1/users/technicians/99999');
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should reject invalid ID format', async () => {
+      const res = await request(app).get('/api/v1/users/technicians/invalid');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('PUT /api/v1/users/technicians/:id', () => {
+    it('should update technician with valid data', async () => {
+      const res = await request(app).put(`/api/v1/users/technicians/${technicianId}`).send({
+        name: 'John Updated',
+        phone: '0779999999'
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.name).toBe('John Updated');
+      expect(res.body.data.phone).toBe('0779999999');
+    });
+
+    it('should not allow email update', async () => {
+      const res = await request(app).put(`/api/v1/users/technicians/${technicianId}`).send({
+        email: 'newemail@test.com'
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+
+    it('should not allow role update', async () => {
+      const res = await request(app).put(`/api/v1/users/technicians/${technicianId}`).send({
+        role: 'branch_manager'
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('DELETE /api/v1/users/technicians/:id', () => {
+    it('should soft delete technician', async () => {
+      const res = await request(app).delete(`/api/v1/users/technicians/${technicianId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toContain('deleted successfully');
+    });
+
+    it('should not find deleted technician', async () => {
+      const res = await request(app).get(`/api/v1/users/technicians/${technicianId}`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body.success).toBe(false);
+    });
+  });
+});
+
+describe('User Endpoints - Branch Managers', () => {
+  let branchManagerId;
+
+  describe('POST /api/v1/users/branch-managers', () => {
+    it('should create a new branch manager', async () => {
+      const res = await request(app).post('/api/v1/users/branch-managers').send({
+        name: 'Manager Mike',
+        email: 'mike.manager@test.com',
+        phone: '0771111111'
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.role).toBe('branch_manager');
+
+      branchManagerId = res.body.data.id;
+    });
+  });
+
+  describe('GET /api/v1/users/branch-managers', () => {
+    it('should get all branch managers', async () => {
+      const res = await request(app).get('/api/v1/users/branch-managers');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      if (res.body.data.length > 0) {
+        expect(res.body.data[0].role).toBe('branch_manager');
+      }
+    });
+  });
+
+  describe('GET /api/v1/users/branch-managers/:id', () => {
+    it('should get branch manager by ID', async () => {
+      const res = await request(app).get(`/api/v1/users/branch-managers/${branchManagerId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.role).toBe('branch_manager');
+    });
+  });
+
+  describe('PUT /api/v1/users/branch-managers/:id', () => {
+    it('should update branch manager', async () => {
+      const res = await request(app).put(`/api/v1/users/branch-managers/${branchManagerId}`).send({
+        name: 'Manager Mike Updated'
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.name).toBe('Manager Mike Updated');
+    });
+  });
+
+  describe('DELETE /api/v1/users/branch-managers/:id', () => {
+    it('should delete branch manager', async () => {
+      const res = await request(app).delete(`/api/v1/users/branch-managers/${branchManagerId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});
+
+describe('User Endpoints - Maintenance Executives', () => {
+  let executiveId;
+
+  describe('POST /api/v1/users/maintenance-executives', () => {
+    it('should create a new maintenance executive', async () => {
+      const res = await request(app).post('/api/v1/users/maintenance-executives').send({
+        name: 'Executive David',
+        email: 'david.exec@test.com',
+        phone: '0772222222'
+      });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.role).toBe('maintenance_executive');
+
+      executiveId = res.body.data.id;
+    });
+  });
+
+  describe('GET /api/v1/users/maintenance-executives', () => {
+    it('should get all maintenance executives', async () => {
+      const res = await request(app).get('/api/v1/users/maintenance-executives');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+    });
+  });
+
+  describe('GET /api/v1/users/maintenance-executives/:id', () => {
+    it('should get maintenance executive by ID', async () => {
+      const res = await request(app).get(`/api/v1/users/maintenance-executives/${executiveId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.role).toBe('maintenance_executive');
+    });
+  });
+
+  describe('PUT /api/v1/users/maintenance-executives/:id', () => {
+    it('should update maintenance executive', async () => {
+      const res = await request(app)
+        .put(`/api/v1/users/maintenance-executives/${executiveId}`)
+        .send({
+          name: 'Executive David Updated'
+        });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+
+  describe('DELETE /api/v1/users/maintenance-executives/:id', () => {
+    it('should delete maintenance executive', async () => {
+      const res = await request(app).delete(`/api/v1/users/maintenance-executives/${executiveId}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});
+
+describe('User Endpoints - General', () => {
+  beforeAll(async () => {
+    // Create sample users for general tests
+    await User.create({
+      name: 'Test User 1',
+      email: 'test1@general.com',
+      role: 'technician',
+      phone: '0773333333',
+      isActive: true
+    });
+    await User.create({
+      name: 'Test User 2',
+      email: 'test2@general.com',
+      role: 'branch_manager',
+      phone: '0774444444',
+      isActive: true
+    });
+  });
+
+  describe('GET /api/v1/users', () => {
+    it('should get all users (all roles)', async () => {
+      const res = await request(app).get('/api/v1/users');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(Array.isArray(res.body.data)).toBe(true);
+      expect(res.body.data.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('GET /api/v1/users/:id', () => {
+    it('should get any user by ID', async () => {
+      const user = await User.findOne({ where: { email: 'test1@general.com' } });
+      const res = await request(app).get(`/api/v1/users/${user.id}`);
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.email).toBe('test1@general.com');
+    });
+  });
+});

--- a/src/controllers/branchManagerController.js
+++ b/src/controllers/branchManagerController.js
@@ -1,0 +1,142 @@
+import userService from '../services/userService.js';
+
+/**
+ * Branch Manager Controller
+ * Handles all HTTP requests for branch manager operations
+ */
+class BranchManagerController {
+  /**
+   * Create a new branch manager
+   * POST /api/v1/users/branch-managers
+   */
+  async createBranchManager(req, res) {
+    try {
+      const branchManagerData = {
+        ...req.body,
+        role: 'branch_manager'
+      };
+
+      const branchManager = await userService.createUser(branchManagerData);
+
+      res.status(201).json({
+        success: true,
+        message: 'Branch manager created successfully',
+        data: branchManager
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get all branch managers
+   * GET /api/v1/users/branch-managers
+   */
+  async getAllBranchManagers(req, res) {
+    try {
+      const branchManagers = await userService.getUsersByRole('branch_manager');
+
+      res.status(200).json({
+        success: true,
+        count: branchManagers.length,
+        data: branchManagers
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get branch manager by ID
+   * GET /api/v1/users/branch-managers/:id
+   */
+  async getBranchManagerById(req, res) {
+    try {
+      const branchManager = await userService.getUserById(req.params.id);
+
+      if (branchManager.role !== 'branch_manager') {
+        return res.status(404).json({
+          success: false,
+          message: 'Branch manager not found'
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+        data: branchManager
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Update branch manager
+   * PUT /api/v1/users/branch-managers/:id
+   */
+  async updateBranchManager(req, res) {
+    try {
+      const branchManager = await userService.getUserById(req.params.id);
+
+      if (branchManager.role !== 'branch_manager') {
+        return res.status(404).json({
+          success: false,
+          message: 'Branch manager not found'
+        });
+      }
+
+      const updatedBranchManager = await userService.updateUser(req.params.id, req.body);
+
+      res.status(200).json({
+        success: true,
+        message: 'Branch manager updated successfully',
+        data: updatedBranchManager
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Delete branch manager (soft delete)
+   * DELETE /api/v1/users/branch-managers/:id
+   */
+  async deleteBranchManager(req, res) {
+    try {
+      const branchManager = await userService.getUserById(req.params.id);
+
+      if (branchManager.role !== 'branch_manager') {
+        return res.status(404).json({
+          success: false,
+          message: 'Branch manager not found'
+        });
+      }
+
+      const result = await userService.deleteUser(req.params.id);
+
+      res.status(200).json({
+        success: true,
+        message: result.message
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+}
+
+export default new BranchManagerController();

--- a/src/controllers/healthController.js
+++ b/src/controllers/healthController.js
@@ -1,7 +1,4 @@
-import { 
-  testDatabaseConnection, 
-  checkMinioConnection 
-} from '../services/connectionService.js';
+import { testDatabaseConnection, checkMinioConnection } from '../services/connectionService.js';
 
 /**
  * Overall health check - tests all services
@@ -9,16 +6,16 @@ import {
 export const getOverallHealth = async (req, res) => {
   try {
     const startTime = Date.now();
-    
+
     // Check database connection
     const dbHealth = await testDatabaseConnection();
-    
+
     // Check MinIO connection
     const storageHealth = await checkMinioConnection();
-    
+
     const responseTime = Date.now() - startTime;
     const isHealthy = dbHealth.connected && storageHealth.connected;
-    
+
     const healthStatus = {
       status: isHealthy ? 'healthy' : 'unhealthy',
       timestamp: new Date().toISOString(),
@@ -43,7 +40,7 @@ export const getOverallHealth = async (req, res) => {
         }
       }
     };
-    
+
     res.status(isHealthy ? 200 : 503).json(healthStatus);
   } catch (error) {
     res.status(500).json({
@@ -63,7 +60,7 @@ export const getDatabaseHealth = async (req, res) => {
     const startTime = Date.now();
     const dbHealth = await testDatabaseConnection();
     const responseTime = Date.now() - startTime;
-    
+
     const response = {
       service: 'database',
       status: dbHealth.connected ? 'healthy' : 'unhealthy',
@@ -77,7 +74,7 @@ export const getDatabaseHealth = async (req, res) => {
         database: process.env.POSTGRES_DB
       }
     };
-    
+
     res.status(dbHealth.connected ? 200 : 503).json(response);
   } catch (error) {
     res.status(500).json({
@@ -98,7 +95,7 @@ export const getStorageHealth = async (req, res) => {
     const startTime = Date.now();
     const storageHealth = await checkMinioConnection();
     const responseTime = Date.now() - startTime;
-    
+
     const response = {
       service: 'storage',
       status: storageHealth.connected ? 'healthy' : 'unhealthy',
@@ -112,7 +109,7 @@ export const getStorageHealth = async (req, res) => {
         consolePort: process.env.MINIO_CONSOLE_PORT || 9001
       }
     };
-    
+
     res.status(storageHealth.connected ? 200 : 503).json(response);
   } catch (error) {
     res.status(500).json({
@@ -132,9 +129,9 @@ export const getReadinessCheck = async (req, res) => {
   try {
     const dbHealth = await testDatabaseConnection();
     const storageHealth = await checkMinioConnection();
-    
+
     const isReady = dbHealth.connected && storageHealth.connected;
-    
+
     if (isReady) {
       res.status(200).json({
         status: 'ready',

--- a/src/controllers/issueController.js
+++ b/src/controllers/issueController.js
@@ -39,7 +39,7 @@ class IssueController {
   async getAllIssues(req, res) {
     try {
       const { branch_id, userid, search, limit, offset } = req.query;
-      
+
       const filters = {};
       if (branch_id) filters.branch_id = parseInt(branch_id);
       if (userid) filters.userid = parseInt(userid);

--- a/src/controllers/maintenanceExecutiveController.js
+++ b/src/controllers/maintenanceExecutiveController.js
@@ -1,0 +1,142 @@
+import userService from '../services/userService.js';
+
+/**
+ * Maintenance Executive Controller
+ * Handles all HTTP requests for maintenance executive operations
+ */
+class MaintenanceExecutiveController {
+  /**
+   * Create a new maintenance executive
+   * POST /api/v1/users/maintenance-executives
+   */
+  async createMaintenanceExecutive(req, res) {
+    try {
+      const executiveData = {
+        ...req.body,
+        role: 'maintenance_executive'
+      };
+
+      const executive = await userService.createUser(executiveData);
+
+      res.status(201).json({
+        success: true,
+        message: 'Maintenance executive created successfully',
+        data: executive
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get all maintenance executives
+   * GET /api/v1/users/maintenance-executives
+   */
+  async getAllMaintenanceExecutives(req, res) {
+    try {
+      const executives = await userService.getUsersByRole('maintenance_executive');
+
+      res.status(200).json({
+        success: true,
+        count: executives.length,
+        data: executives
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get maintenance executive by ID
+   * GET /api/v1/users/maintenance-executives/:id
+   */
+  async getMaintenanceExecutiveById(req, res) {
+    try {
+      const executive = await userService.getUserById(req.params.id);
+
+      if (executive.role !== 'maintenance_executive') {
+        return res.status(404).json({
+          success: false,
+          message: 'Maintenance executive not found'
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+        data: executive
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Update maintenance executive
+   * PUT /api/v1/users/maintenance-executives/:id
+   */
+  async updateMaintenanceExecutive(req, res) {
+    try {
+      const executive = await userService.getUserById(req.params.id);
+
+      if (executive.role !== 'maintenance_executive') {
+        return res.status(404).json({
+          success: false,
+          message: 'Maintenance executive not found'
+        });
+      }
+
+      const updatedExecutive = await userService.updateUser(req.params.id, req.body);
+
+      res.status(200).json({
+        success: true,
+        message: 'Maintenance executive updated successfully',
+        data: updatedExecutive
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Delete maintenance executive (soft delete)
+   * DELETE /api/v1/users/maintenance-executives/:id
+   */
+  async deleteMaintenanceExecutive(req, res) {
+    try {
+      const executive = await userService.getUserById(req.params.id);
+
+      if (executive.role !== 'maintenance_executive') {
+        return res.status(404).json({
+          success: false,
+          message: 'Maintenance executive not found'
+        });
+      }
+
+      const result = await userService.deleteUser(req.params.id);
+
+      res.status(200).json({
+        success: true,
+        message: result.message
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+}
+
+export default new MaintenanceExecutiveController();

--- a/src/controllers/technicianController.js
+++ b/src/controllers/technicianController.js
@@ -1,0 +1,142 @@
+import userService from '../services/userService.js';
+
+/**
+ * Technician Controller
+ * Handles all HTTP requests for technician operations
+ */
+class TechnicianController {
+  /**
+   * Create a new technician
+   * POST /api/v1/users/technicians
+   */
+  async createTechnician(req, res) {
+    try {
+      const technicianData = {
+        ...req.body,
+        role: 'technician'
+      };
+
+      const technician = await userService.createUser(technicianData);
+
+      res.status(201).json({
+        success: true,
+        message: 'Technician created successfully',
+        data: technician
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get all technicians
+   * GET /api/v1/users/technicians
+   */
+  async getAllTechnicians(req, res) {
+    try {
+      const technicians = await userService.getUsersByRole('technician');
+
+      res.status(200).json({
+        success: true,
+        count: technicians.length,
+        data: technicians
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Get technician by ID
+   * GET /api/v1/users/technicians/:id
+   */
+  async getTechnicianById(req, res) {
+    try {
+      const technician = await userService.getUserById(req.params.id);
+
+      if (technician.role !== 'technician') {
+        return res.status(404).json({
+          success: false,
+          message: 'Technician not found'
+        });
+      }
+
+      res.status(200).json({
+        success: true,
+        data: technician
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Update technician
+   * PUT /api/v1/users/technicians/:id
+   */
+  async updateTechnician(req, res) {
+    try {
+      const technician = await userService.getUserById(req.params.id);
+
+      if (technician.role !== 'technician') {
+        return res.status(404).json({
+          success: false,
+          message: 'Technician not found'
+        });
+      }
+
+      const updatedTechnician = await userService.updateUser(req.params.id, req.body);
+
+      res.status(200).json({
+        success: true,
+        message: 'Technician updated successfully',
+        data: updatedTechnician
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Delete technician (soft delete)
+   * DELETE /api/v1/users/technicians/:id
+   */
+  async deleteTechnician(req, res) {
+    try {
+      const technician = await userService.getUserById(req.params.id);
+
+      if (technician.role !== 'technician') {
+        return res.status(404).json({
+          success: false,
+          message: 'Technician not found'
+        });
+      }
+
+      const result = await userService.deleteUser(req.params.id);
+
+      res.status(200).json({
+        success: true,
+        message: result.message
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+}
+
+export default new TechnicianController();

--- a/src/database/migrations/20251011000000-create-users-table.cjs
+++ b/src/database/migrations/20251011000000-create-users-table.cjs
@@ -1,0 +1,72 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Users', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      name: {
+        type: Sequelize.STRING(255),
+        allowNull: false
+      },
+      email: {
+        type: Sequelize.STRING(255),
+        allowNull: false,
+        unique: true
+      },
+      password: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        comment: 'Optional field for future authentication'
+      },
+      role: {
+        type: Sequelize.ENUM('technician', 'branch_manager', 'maintenance_executive'),
+        allowNull: false
+      },
+      phone: {
+        type: Sequelize.STRING(20),
+        allowNull: true
+      },
+      profilePicture: {
+        type: Sequelize.STRING(500),
+        allowNull: true,
+        comment: 'URL to profile picture in MinIO storage'
+      },
+      isActive: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Add index on email for faster lookups
+    await queryInterface.addIndex('Users', ['email'], {
+      name: 'users_email_idx',
+      unique: true
+    });
+
+    // Add index on role for filtering
+    await queryInterface.addIndex('Users', ['role'], {
+      name: 'users_role_idx'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Users');
+  }
+};

--- a/src/database/seeders/20251011000000-demo-users.cjs
+++ b/src/database/seeders/20251011000000-demo-users.cjs
@@ -1,0 +1,79 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.bulkInsert('Users', [
+      {
+        name: 'John Technician',
+        email: 'john.tech@dominoslk.com',
+        password: 'password123',
+        role: 'technician',
+        phone: '0771234567',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: 'Sarah Technician',
+        email: 'sarah.tech@dominoslk.com',
+        password: 'password123',
+        role: 'technician',
+        phone: '0772345678',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: 'Mike Manager',
+        email: 'mike.manager@dominoslk.com',
+        password: 'password123',
+        role: 'branch_manager',
+        phone: '0773456789',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: 'Lisa Manager',
+        email: 'lisa.manager@dominoslk.com',
+        password: 'password123',
+        role: 'branch_manager',
+        phone: '0774567890',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: 'David Executive',
+        email: 'david.exec@dominoslk.com',
+        password: 'password123',
+        role: 'maintenance_executive',
+        phone: '0775678901',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        name: 'Emma Executive',
+        email: 'emma.exec@dominoslk.com',
+        password: 'password123',
+        role: 'maintenance_executive',
+        phone: '0776789012',
+        profilePicture: null,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ], {});
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('Users', null, {});
+  }
+};

--- a/src/middleware/validation.js
+++ b/src/middleware/validation.js
@@ -1,0 +1,93 @@
+import { body, param, validationResult } from 'express-validator';
+
+/**
+ * Middleware to handle validation errors
+ */
+export const handleValidationErrors = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      success: false,
+      errors: errors.array().map(err => ({
+        field: err.path,
+        message: err.msg
+      }))
+    });
+  }
+  next();
+};
+
+/**
+ * Validation rules for creating a user
+ */
+export const validateCreateUser = [
+  body('name')
+    .trim()
+    .notEmpty()
+    .withMessage('Name is required')
+    .isLength({ min: 2, max: 255 })
+    .withMessage('Name must be between 2 and 255 characters'),
+
+  body('email')
+    .trim()
+    .notEmpty()
+    .withMessage('Email is required')
+    .isEmail()
+    .withMessage('Must be a valid email address')
+    .normalizeEmail(),
+
+  body('phone')
+    .optional()
+    .trim()
+    .isLength({ min: 10, max: 20 })
+    .withMessage('Phone number must be between 10 and 20 characters'),
+
+  body('password')
+    .optional()
+    .isLength({ min: 6 })
+    .withMessage('Password must be at least 6 characters'),
+
+  body('profilePicture').optional().isURL().withMessage('Profile picture must be a valid URL'),
+
+  handleValidationErrors
+];
+
+/**
+ * Validation rules for updating a user
+ */
+export const validateUpdateUser = [
+  body('name')
+    .optional()
+    .trim()
+    .isLength({ min: 2, max: 255 })
+    .withMessage('Name must be between 2 and 255 characters'),
+
+  body('phone')
+    .optional()
+    .trim()
+    .isLength({ min: 10, max: 20 })
+    .withMessage('Phone number must be between 10 and 20 characters'),
+
+  body('password')
+    .optional()
+    .isLength({ min: 6 })
+    .withMessage('Password must be at least 6 characters'),
+
+  body('profilePicture').optional().isURL().withMessage('Profile picture must be a valid URL'),
+
+  // Don't allow these fields to be updated
+  body('email').not().exists().withMessage('Email cannot be updated'),
+  body('role').not().exists().withMessage('Role cannot be updated'),
+  body('isActive').not().exists().withMessage('isActive cannot be updated'),
+
+  handleValidationErrors
+];
+
+/**
+ * Validation for user ID parameter
+ */
+export const validateUserId = [
+  param('id').isInt({ min: 1 }).withMessage('User ID must be a positive integer'),
+
+  handleValidationErrors
+];

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,11 +1,13 @@
 import { getSequelizeInstance } from '../services/connectionService.js';
 import Issue from './issue.js';
+import User from './user.js';
 
 const sequelize = getSequelizeInstance();
 
 // Initialize all models
 const models = {
   Issue,
+  User,
   sequelize
 };
 
@@ -13,6 +15,7 @@ const models = {
 // For example:
 // Issue.belongsTo(User, { foreignKey: 'userid' });
 // Issue.belongsTo(Branch, { foreignKey: 'branch_id' });
+// Note: No relationships defined yet to avoid conflicts during development
 
 export default models;
-export { Issue, sequelize };
+export { Issue, User, sequelize };

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,0 +1,98 @@
+import { DataTypes } from 'sequelize';
+import { getSequelizeInstance } from '../services/connectionService.js';
+
+const sequelize = getSequelizeInstance();
+
+const User = sequelize.define(
+  'User',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false
+    },
+    name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      validate: {
+        notNull: {
+          msg: 'Name is required'
+        },
+        notEmpty: {
+          msg: 'Name cannot be empty'
+        },
+        len: {
+          args: [2, 255],
+          msg: 'Name must be between 2 and 255 characters'
+        }
+      }
+    },
+    email: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      unique: true,
+      validate: {
+        notNull: {
+          msg: 'Email is required'
+        },
+        isEmail: {
+          msg: 'Must be a valid email address'
+        }
+      }
+    },
+    password: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      comment: 'Optional field for future authentication'
+    },
+    role: {
+      type: DataTypes.ENUM('technician', 'branch_manager', 'maintenance_executive'),
+      allowNull: false,
+      validate: {
+        notNull: {
+          msg: 'Role is required'
+        },
+        isIn: {
+          args: [['technician', 'branch_manager', 'maintenance_executive']],
+          msg: 'Role must be technician, branch_manager, or maintenance_executive'
+        }
+      }
+    },
+    phone: {
+      type: DataTypes.STRING(20),
+      allowNull: true,
+      validate: {
+        len: {
+          args: [10, 20],
+          msg: 'Phone number must be between 10 and 20 characters'
+        }
+      }
+    },
+    profilePicture: {
+      type: DataTypes.STRING(500),
+      allowNull: true,
+      comment: 'URL to profile picture in MinIO storage'
+    },
+    isActive: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true
+    }
+  },
+  {
+    tableName: 'Users',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['email']
+      },
+      {
+        fields: ['role']
+      }
+    ]
+  }
+);
+
+export default User;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,0 +1,203 @@
+import express from 'express';
+import technicianController from '../controllers/technicianController.js';
+import branchManagerController from '../controllers/branchManagerController.js';
+import maintenanceExecutiveController from '../controllers/maintenanceExecutiveController.js';
+import userService from '../services/userService.js';
+import {
+  validateCreateUser,
+  validateUpdateUser,
+  validateUserId
+} from '../middleware/validation.js';
+
+const router = express.Router();
+
+// ============================================
+// TECHNICIAN ROUTES
+// ============================================
+
+/**
+ * @route   POST /api/v1/users/technicians
+ * @desc    Create a new technician
+ * @access  Public (no auth for now)
+ */
+router.post('/technicians', validateCreateUser, technicianController.createTechnician);
+
+/**
+ * @route   GET /api/v1/users/technicians
+ * @desc    Get all technicians
+ * @access  Public
+ */
+router.get('/technicians', technicianController.getAllTechnicians);
+
+/**
+ * @route   GET /api/v1/users/technicians/:id
+ * @desc    Get technician by ID
+ * @access  Public
+ */
+router.get('/technicians/:id', validateUserId, technicianController.getTechnicianById);
+
+/**
+ * @route   PUT /api/v1/users/technicians/:id
+ * @desc    Update technician
+ * @access  Public
+ */
+router.put(
+  '/technicians/:id',
+  validateUserId,
+  validateUpdateUser,
+  technicianController.updateTechnician
+);
+
+/**
+ * @route   DELETE /api/v1/users/technicians/:id
+ * @desc    Delete technician (soft delete)
+ * @access  Public
+ */
+router.delete('/technicians/:id', validateUserId, technicianController.deleteTechnician);
+
+// ============================================
+// BRANCH MANAGER ROUTES
+// ============================================
+
+/**
+ * @route   POST /api/v1/users/branch-managers
+ * @desc    Create a new branch manager
+ * @access  Public
+ */
+router.post('/branch-managers', validateCreateUser, branchManagerController.createBranchManager);
+
+/**
+ * @route   GET /api/v1/users/branch-managers
+ * @desc    Get all branch managers
+ * @access  Public
+ */
+router.get('/branch-managers', branchManagerController.getAllBranchManagers);
+
+/**
+ * @route   GET /api/v1/users/branch-managers/:id
+ * @desc    Get branch manager by ID
+ * @access  Public
+ */
+router.get('/branch-managers/:id', validateUserId, branchManagerController.getBranchManagerById);
+
+/**
+ * @route   PUT /api/v1/users/branch-managers/:id
+ * @desc    Update branch manager
+ * @access  Public
+ */
+router.put(
+  '/branch-managers/:id',
+  validateUserId,
+  validateUpdateUser,
+  branchManagerController.updateBranchManager
+);
+
+/**
+ * @route   DELETE /api/v1/users/branch-managers/:id
+ * @desc    Delete branch manager (soft delete)
+ * @access  Public
+ */
+router.delete('/branch-managers/:id', validateUserId, branchManagerController.deleteBranchManager);
+
+// ============================================
+// MAINTENANCE EXECUTIVE ROUTES
+// ============================================
+
+/**
+ * @route   POST /api/v1/users/maintenance-executives
+ * @desc    Create a new maintenance executive
+ * @access  Public
+ */
+router.post(
+  '/maintenance-executives',
+  validateCreateUser,
+  maintenanceExecutiveController.createMaintenanceExecutive
+);
+
+/**
+ * @route   GET /api/v1/users/maintenance-executives
+ * @desc    Get all maintenance executives
+ * @access  Public
+ */
+router.get('/maintenance-executives', maintenanceExecutiveController.getAllMaintenanceExecutives);
+
+/**
+ * @route   GET /api/v1/users/maintenance-executives/:id
+ * @desc    Get maintenance executive by ID
+ * @access  Public
+ */
+router.get(
+  '/maintenance-executives/:id',
+  validateUserId,
+  maintenanceExecutiveController.getMaintenanceExecutiveById
+);
+
+/**
+ * @route   PUT /api/v1/users/maintenance-executives/:id
+ * @desc    Update maintenance executive
+ * @access  Public
+ */
+router.put(
+  '/maintenance-executives/:id',
+  validateUserId,
+  validateUpdateUser,
+  maintenanceExecutiveController.updateMaintenanceExecutive
+);
+
+/**
+ * @route   DELETE /api/v1/users/maintenance-executives/:id
+ * @desc    Delete maintenance executive (soft delete)
+ * @access  Public
+ */
+router.delete(
+  '/maintenance-executives/:id',
+  validateUserId,
+  maintenanceExecutiveController.deleteMaintenanceExecutive
+);
+
+// ============================================
+// GENERAL USER ROUTES (Optional)
+// ============================================
+
+/**
+ * @route   GET /api/v1/users
+ * @desc    Get all users (all roles)
+ * @access  Public
+ */
+router.get('/', async (req, res) => {
+  try {
+    const users = await userService.getAllUsers();
+    res.status(200).json({
+      success: true,
+      count: users.length,
+      data: users
+    });
+  } catch (error) {
+    res.status(500).json({
+      success: false,
+      message: error.message
+    });
+  }
+});
+
+/**
+ * @route   GET /api/v1/users/:id
+ * @desc    Get any user by ID
+ * @access  Public
+ */
+router.get('/:id', validateUserId, async (req, res) => {
+  try {
+    const user = await userService.getUserById(req.params.id);
+    res.status(200).json({
+      success: true,
+      data: user
+    });
+  } catch (error) {
+    res.status(404).json({
+      success: false,
+      message: error.message
+    });
+  }
+});
+
+export default router;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,122 @@
+import User from '../models/user.js';
+
+/**
+ * User Service - Contains all business logic for user operations
+ * Handles CRUD operations for technicians, branch managers, and maintenance executives
+ */
+class UserService {
+  /**
+   * Create a new user
+   * @param {Object} userData - User data
+   * @returns {Promise<Object>} Created user
+   */
+  async createUser(userData) {
+    try {
+      const user = await User.create(userData);
+      // Don't return password in response
+      const userResponse = user.toJSON();
+      delete userResponse.password;
+      return userResponse;
+    } catch (error) {
+      if (error.name === 'SequelizeUniqueConstraintError') {
+        throw new Error('Email already exists');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Get all users, optionally filtered by role
+   * @param {string} role - Optional role filter
+   * @returns {Promise<Array>} List of users
+   */
+  async getAllUsers(role = null) {
+    const where = { isActive: true };
+    if (role) {
+      where.role = role;
+    }
+
+    const users = await User.findAll({
+      where,
+      attributes: { exclude: ['password'] },
+      order: [['createdAt', 'DESC']]
+    });
+
+    return users;
+  }
+
+  /**
+   * Get user by ID
+   * @param {number} userId - User ID
+   * @returns {Promise<Object>} User object
+   */
+  async getUserById(userId) {
+    const user = await User.findOne({
+      where: { id: userId, isActive: true },
+      attributes: { exclude: ['password'] }
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return user;
+  }
+
+  /**
+   * Update user by ID
+   * @param {number} userId - User ID
+   * @param {Object} updateData - Data to update
+   * @returns {Promise<Object>} Updated user
+   */
+  async updateUser(userId, updateData) {
+    const user = await User.findOne({
+      where: { id: userId, isActive: true }
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    // Don't allow role or email updates through regular update
+    delete updateData.role;
+    delete updateData.email;
+    delete updateData.isActive;
+
+    await user.update(updateData);
+
+    const updatedUser = user.toJSON();
+    delete updatedUser.password;
+    return updatedUser;
+  }
+
+  /**
+   * Soft delete user by ID
+   * @param {number} userId - User ID
+   * @returns {Promise<Object>} Success message
+   */
+  async deleteUser(userId) {
+    const user = await User.findOne({
+      where: { id: userId, isActive: true }
+    });
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    await user.update({ isActive: false });
+
+    return { message: 'User deleted successfully' };
+  }
+
+  /**
+   * Get users by role
+   * @param {string} role - User role
+   * @returns {Promise<Array>} List of users
+   */
+  async getUsersByRole(role) {
+    return this.getAllUsers(role);
+  }
+}
+
+export default new UserService();


### PR DESCRIPTION
- Add User model with role-based access (technician, branch_manager, maintenance_executive)
- Implement CRUD operations for all user types
- Create role-specific controllers (technician, branch manager, maintenance executive)
- Add comprehensive input validation middleware using express-validator
- Include 26 test cases covering all CRUD operations
- Add database migration for Users table
- Add sample user seeder for testing
- Update server.js to register user routes
- No model relationships to avoid conflicts during development

All tests passing (38/38)
No breaking changes to existing endpoints