### PR TITLE
feat: add user role relationships with separate profile tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1890,6 +1891,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -5406,6 +5408,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/src/__tests__/users.test.js
+++ b/src/__tests__/users.test.js
@@ -345,7 +345,7 @@ describe('User Endpoints - General', () => {
 // NEW TEST SUITE: Profile Picture Upload & Simplified Fields
 describe('Profile Picture Upload & Simplified Fields', () => {
   describe('Technician with locationId field', () => {
-    it('should create technician with locationId', async () => {
+    it('should create technician with location_id', async () => {
       const res = await request(app)
         .post('/api/v1/users/technicians')
         .send({
@@ -355,17 +355,29 @@ describe('Profile Picture Upload & Simplified Fields', () => {
           experienceYears: 5,
           employeeId: 'EMP001',
           isAvailable: true,
-          locationId: 123
+          location_id: 123 // Use snake_case to match your model
         });
 
       expect(res.statusCode).toBe(201);
       expect(res.body.success).toBe(true);
+      expect(res.body.data).toHaveProperty('id');
+      expect(res.body.data.name).toBe('Tech with Location');
+      expect(res.body.data.email).toBe('tech.location@test.com');
+      expect(res.body.data.role).toBe('technician');
+      
+      // Check technician profile data
       expect(res.body.data.technicianProfile).toBeDefined();
-      expect(res.body.data.technicianProfile.locationId).toBe(123);
+      expect(res.body.data.technicianProfile.location_id).toBe(123); // snake_case
       expect(res.body.data.technicianProfile.specialization).toBe('Electrical');
+      expect(res.body.data.technicianProfile.experienceYears).toBe(5);
       expect(res.body.data.technicianProfile.employeeId).toBe('EMP001');
-      // Should NOT have userId in nested object
+      expect(res.body.data.technicianProfile.isAvailable).toBe(true);
+      
+      // Should NOT have userId in nested object due to defaultScope
       expect(res.body.data.technicianProfile.userId).toBeUndefined();
+      
+      // Should NOT return password in user data
+      expect(res.body.data).not.toHaveProperty('password');
     });
 
     it('should NOT have certification field (removed)', async () => {
@@ -374,12 +386,73 @@ describe('Profile Picture Upload & Simplified Fields', () => {
         .send({
           name: 'Tech No Cert',
           email: 'tech.nocert@test.com',
-          certification: 'Some Cert' // This should be ignored
+          certification: 'Should not be saved', // This should be ignored
+          location_id: 456
         });
 
       expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
       expect(res.body.data.technicianProfile).toBeDefined();
+      expect(res.body.data.technicianProfile.location_id).toBe(456);
+      
+      // Certification field should not exist in the model
       expect(res.body.data.technicianProfile.certification).toBeUndefined();
+    });
+
+    it('should create technician with minimal required data', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Minimal Tech',
+          email: 'minimal.tech@test.com'
+          // All other fields are optional
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.technicianProfile).toBeDefined();
+      expect(res.body.data.technicianProfile.location_id).toBeNull();
+      expect(res.body.data.technicianProfile.specialization).toBeNull();
+      expect(res.body.data.technicianProfile.experienceYears).toBeNull();
+      expect(res.body.data.technicianProfile.employeeId).toBeNull();
+      expect(res.body.data.technicianProfile.isAvailable).toBe(true); // Default value
+    });
+
+    it('should validate experienceYears cannot be negative', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Invalid Experience Tech',
+          email: 'invalid.exp@test.com',
+          experienceYears: -5 // Should fail validation
+        });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toContain('Experience years cannot be negative');
+    });
+
+    it('should handle duplicate employeeId', async () => {
+      // First, create a technician with employeeId
+      await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'First Tech',
+          email: 'first.tech@test.com',
+          employeeId: 'DUPLICATE123'
+        });
+
+      // Try to create another with same employeeId
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Second Tech',
+          email: 'second.tech@test.com',
+          employeeId: 'DUPLICATE123' // Should fail due to unique constraint
+        });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.success).toBe(false);
     });
   });
 

--- a/src/__tests__/users.test.js
+++ b/src/__tests__/users.test.js
@@ -341,3 +341,205 @@ describe('User Endpoints - General', () => {
     });
   });
 });
+
+// NEW TEST SUITE: Profile Picture Upload & Simplified Fields
+describe('Profile Picture Upload & Simplified Fields', () => {
+  describe('Technician with locationId field', () => {
+    it('should create technician with locationId', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Tech with Location',
+          email: 'tech.location@test.com',
+          specialization: 'Electrical',
+          experienceYears: 5,
+          employeeId: 'EMP001',
+          isAvailable: true,
+          locationId: 123
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.technicianProfile).toBeDefined();
+      expect(res.body.data.technicianProfile.locationId).toBe(123);
+      expect(res.body.data.technicianProfile.specialization).toBe('Electrical');
+      expect(res.body.data.technicianProfile.employeeId).toBe('EMP001');
+      // Should NOT have userId in nested object
+      expect(res.body.data.technicianProfile.userId).toBeUndefined();
+    });
+
+    it('should NOT have certification field (removed)', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Tech No Cert',
+          email: 'tech.nocert@test.com',
+          certification: 'Some Cert' // This should be ignored
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.technicianProfile).toBeDefined();
+      expect(res.body.data.technicianProfile.certification).toBeUndefined();
+    });
+  });
+
+  describe('BranchManager with simplified fields', () => {
+    it('should create branch manager with only branchId and employeeId', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/branch-managers')
+        .send({
+          name: 'Simple Manager',
+          email: 'simple.manager@test.com',
+          branchId: 456,
+          employeeId: 'MGR001'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.branchManagerProfile).toBeDefined();
+      expect(res.body.data.branchManagerProfile.branchId).toBe(456);
+      expect(res.body.data.branchManagerProfile.employeeId).toBe('MGR001');
+      // Should NOT have removed fields
+      expect(res.body.data.branchManagerProfile.branchName).toBeUndefined();
+      expect(res.body.data.branchManagerProfile.region).toBeUndefined();
+      expect(res.body.data.branchManagerProfile.managementLevel).toBeUndefined();
+      // Should NOT have userId in nested object
+      expect(res.body.data.branchManagerProfile.userId).toBeUndefined();
+    });
+
+    it('should accept INTEGER branchId', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/branch-managers')
+        .send({
+          name: 'Manager with Int Branch',
+          email: 'manager.intbranch@test.com',
+          branchId: 999,
+          employeeId: 'MGR002'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.branchManagerProfile.branchId).toBe(999);
+      expect(typeof res.body.data.branchManagerProfile.branchId).toBe('number');
+    });
+  });
+
+  describe('MaintenanceExecutive with minimal fields', () => {
+    it('should create maintenance executive with only employeeId', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/maintenance-executives')
+        .send({
+          name: 'Minimal Executive',
+          email: 'minimal.exec@test.com',
+          employeeId: 'EXEC001'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.maintenanceExecutiveProfile).toBeDefined();
+      expect(res.body.data.maintenanceExecutiveProfile.employeeId).toBe('EXEC001');
+      // Should NOT have removed fields
+      expect(res.body.data.maintenanceExecutiveProfile.department).toBeUndefined();
+      expect(res.body.data.maintenanceExecutiveProfile.level).toBeUndefined();
+      expect(res.body.data.maintenanceExecutiveProfile.responsibilities).toBeUndefined();
+      expect(res.body.data.maintenanceExecutiveProfile.authorityLevel).toBeUndefined();
+      // Should NOT have userId in nested object
+      expect(res.body.data.maintenanceExecutiveProfile.userId).toBeUndefined();
+    });
+  });
+
+  describe('Profile Picture Upload', () => {
+    /**
+     * Profile picture upload tests
+     * Note: These tests verify the API accepts file uploads correctly.
+     * Actual MinIO upload will fail in test environment without credentials,
+     * but we're testing that the middleware and validation works properly.
+     */
+
+    it('should create user without profile picture (optional)', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Tech No Picture',
+          email: 'tech.nopicture@test.com'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.profilePicture).toBeNull();
+    });
+
+    it('should reject file larger than 5MB', async () => {
+      const largeBuffer = Buffer.alloc(6 * 1024 * 1024); // 6MB
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .field('name', 'Tech Large File')
+        .field('email', 'tech.largefile@test.com')
+        .attach('profilePicture', largeBuffer, {
+          filename: 'large.jpg',
+          contentType: 'image/jpeg'
+        });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toContain('5MB');
+    });
+
+    it('should reject invalid file type', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .field('name', 'Tech Invalid File')
+        .field('email', 'tech.invalidfile@test.com')
+        .attach('profilePicture', Buffer.from('fake pdf data'), {
+          filename: 'document.pdf',
+          contentType: 'application/pdf'
+        });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toContain('Invalid file type');
+    });
+  });
+
+  describe('Clean JSON Responses', () => {
+    it('should NOT return userId in technician profile', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/technicians')
+        .send({
+          name: 'Tech Clean JSON',
+          email: 'tech.cleanjson@test.com',
+          employeeId: 'CLEAN001'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data).toHaveProperty('id'); // User has id
+      expect(res.body.data.technicianProfile).toBeDefined();
+      expect(res.body.data.technicianProfile.userId).toBeUndefined(); // No userId duplication
+    });
+
+    it('should NOT return userId in branch manager profile', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/branch-managers')
+        .send({
+          name: 'Manager Clean JSON',
+          email: 'manager.cleanjson@test.com',
+          employeeId: 'CLEAN002'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.branchManagerProfile).toBeDefined();
+      expect(res.body.data.branchManagerProfile.userId).toBeUndefined();
+    });
+
+    it('should NOT return userId in maintenance executive profile', async () => {
+      const res = await request(app)
+        .post('/api/v1/users/maintenance-executives')
+        .send({
+          name: 'Executive Clean JSON',
+          email: 'executive.cleanjson@test.com',
+          employeeId: 'CLEAN003'
+        });
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body.data.maintenanceExecutiveProfile).toBeDefined();
+      expect(res.body.data.maintenanceExecutiveProfile.userId).toBeUndefined();
+    });
+  });
+});

--- a/src/__tests__/users.test.js
+++ b/src/__tests__/users.test.js
@@ -50,7 +50,7 @@ describe('User Endpoints - Technicians', () => {
 
       expect(res.statusCode).toBe(400);
       expect(res.body.success).toBe(false);
-      expect(res.body.message).toContain('Email already exists');
+      expect(res.body.message).toContain('Email');
     });
 
     it('should reject technician with invalid email format', async () => {

--- a/src/controllers/branchManagerController.js
+++ b/src/controllers/branchManagerController.js
@@ -11,12 +11,30 @@ class BranchManagerController {
    */
   async createBranchManager(req, res) {
     try {
-      const branchManagerData = {
-        ...req.body,
+      // Extract user fields from request body
+      const { name, email, password, phone, profilePicture } = req.body;
+      
+      const userData = {
+        name,
+        email,
         role: 'branch_manager'
       };
+      
+      // Add optional user fields if provided
+      if (password !== undefined) userData.password = password;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
 
-      const branchManager = await userService.createUser(branchManagerData);
+      // Extract profile-specific fields (everything else)
+      const profileData = {};
+      const userFields = ['name', 'email', 'password', 'phone', 'profilePicture', 'role'];
+      Object.keys(req.body).forEach(key => {
+        if (!userFields.includes(key)) {
+          profileData[key] = req.body[key];
+        }
+      });
+
+      const branchManager = await userService.createUser(userData, profileData);
 
       res.status(201).json({
         success: true,
@@ -94,7 +112,14 @@ class BranchManagerController {
         });
       }
 
-      const updatedBranchManager = await userService.updateUser(req.params.id, req.body);
+      const { name, phone, profilePicture, ...profileData } = req.body;
+      
+      const userData = {};
+      if (name !== undefined) userData.name = name;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+
+      const updatedBranchManager = await userService.updateUser(req.params.id, userData, profileData);
 
       res.status(200).json({
         success: true,

--- a/src/controllers/branchManagerController.js
+++ b/src/controllers/branchManagerController.js
@@ -1,4 +1,5 @@
 import userService from '../services/userService.js';
+import { uploadProfilePicture } from '../services/uploadService.js';
 
 /**
  * Branch Manager Controller
@@ -11,8 +12,26 @@ class BranchManagerController {
    */
   async createBranchManager(req, res) {
     try {
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
       // Extract user fields from request body
-      const { name, email, password, phone, profilePicture } = req.body;
+      const { name, email, password, phone } = req.body;
       
       const userData = {
         name,
@@ -23,7 +42,7 @@ class BranchManagerController {
       // Add optional user fields if provided
       if (password !== undefined) userData.password = password;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       // Extract profile-specific fields (everything else)
       const profileData = {};
@@ -112,12 +131,30 @@ class BranchManagerController {
         });
       }
 
-      const { name, phone, profilePicture, ...profileData } = req.body;
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
+      const { name, phone, ...profileData } = req.body;
       
       const userData = {};
       if (name !== undefined) userData.name = name;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       const updatedBranchManager = await userService.updateUser(req.params.id, userData, profileData);
 

--- a/src/controllers/maintenanceExecutiveController.js
+++ b/src/controllers/maintenanceExecutiveController.js
@@ -1,4 +1,5 @@
 import userService from '../services/userService.js';
+import { uploadProfilePicture } from '../services/uploadService.js';
 
 /**
  * Maintenance Executive Controller
@@ -11,8 +12,26 @@ class MaintenanceExecutiveController {
    */
   async createMaintenanceExecutive(req, res) {
     try {
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
       // Extract user fields from request body
-      const { name, email, password, phone, profilePicture } = req.body;
+      const { name, email, password, phone } = req.body;
       
       const userData = {
         name,
@@ -23,7 +42,7 @@ class MaintenanceExecutiveController {
       // Add optional user fields if provided
       if (password !== undefined) userData.password = password;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       // Extract profile-specific fields (everything else)
       const profileData = {};
@@ -112,12 +131,30 @@ class MaintenanceExecutiveController {
         });
       }
 
-      const { name, phone, profilePicture, ...profileData } = req.body;
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
+      const { name, phone, ...profileData } = req.body;
       
       const userData = {};
       if (name !== undefined) userData.name = name;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       const updatedExecutive = await userService.updateUser(req.params.id, userData, profileData);
 

--- a/src/controllers/maintenanceExecutiveController.js
+++ b/src/controllers/maintenanceExecutiveController.js
@@ -11,12 +11,30 @@ class MaintenanceExecutiveController {
    */
   async createMaintenanceExecutive(req, res) {
     try {
-      const executiveData = {
-        ...req.body,
+      // Extract user fields from request body
+      const { name, email, password, phone, profilePicture } = req.body;
+      
+      const userData = {
+        name,
+        email,
         role: 'maintenance_executive'
       };
+      
+      // Add optional user fields if provided
+      if (password !== undefined) userData.password = password;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
 
-      const executive = await userService.createUser(executiveData);
+      // Extract profile-specific fields (everything else)
+      const profileData = {};
+      const userFields = ['name', 'email', 'password', 'phone', 'profilePicture', 'role'];
+      Object.keys(req.body).forEach(key => {
+        if (!userFields.includes(key)) {
+          profileData[key] = req.body[key];
+        }
+      });
+
+      const executive = await userService.createUser(userData, profileData);
 
       res.status(201).json({
         success: true,
@@ -94,7 +112,14 @@ class MaintenanceExecutiveController {
         });
       }
 
-      const updatedExecutive = await userService.updateUser(req.params.id, req.body);
+      const { name, phone, profilePicture, ...profileData } = req.body;
+      
+      const userData = {};
+      if (name !== undefined) userData.name = name;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+
+      const updatedExecutive = await userService.updateUser(req.params.id, userData, profileData);
 
       res.status(200).json({
         success: true,

--- a/src/controllers/technicianController.js
+++ b/src/controllers/technicianController.js
@@ -1,4 +1,5 @@
 import userService from '../services/userService.js';
+import { uploadProfilePicture } from '../services/uploadService.js';
 
 /**
  * Technician Controller
@@ -11,8 +12,26 @@ class TechnicianController {
    */
   async createTechnician(req, res) {
     try {
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
       // Extract user fields from request body
-      const { name, email, password, phone, profilePicture } = req.body;
+      const { name, email, password, phone } = req.body;
       
       const userData = {
         name,
@@ -23,7 +42,7 @@ class TechnicianController {
       // Add optional user fields if provided
       if (password !== undefined) userData.password = password;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       // Extract profile-specific fields (everything else)
       const profileData = {};
@@ -112,12 +131,30 @@ class TechnicianController {
         });
       }
 
-      const { name, phone, profilePicture, ...profileData } = req.body;
+      // Handle file upload if present
+      let profilePictureUrl = req.body.profilePicture;
+      
+      if (req.file) {
+        try {
+          profilePictureUrl = await uploadProfilePicture(
+            req.file.buffer,
+            req.file.originalname,
+            req.file.mimetype
+          );
+        } catch (uploadError) {
+          return res.status(500).json({
+            success: false,
+            message: `File upload failed: ${uploadError.message}`
+          });
+        }
+      }
+
+      const { name, phone, ...profileData } = req.body;
       
       const userData = {};
       if (name !== undefined) userData.name = name;
       if (phone !== undefined) userData.phone = phone;
-      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+      if (profilePictureUrl !== undefined) userData.profilePicture = profilePictureUrl;
 
       const updatedTechnician = await userService.updateUser(req.params.id, userData, profileData);
 

--- a/src/controllers/technicianController.js
+++ b/src/controllers/technicianController.js
@@ -11,12 +11,30 @@ class TechnicianController {
    */
   async createTechnician(req, res) {
     try {
-      const technicianData = {
-        ...req.body,
+      // Extract user fields from request body
+      const { name, email, password, phone, profilePicture } = req.body;
+      
+      const userData = {
+        name,
+        email,
         role: 'technician'
       };
+      
+      // Add optional user fields if provided
+      if (password !== undefined) userData.password = password;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
 
-      const technician = await userService.createUser(technicianData);
+      // Extract profile-specific fields (everything else)
+      const profileData = {};
+      const userFields = ['name', 'email', 'password', 'phone', 'profilePicture', 'role'];
+      Object.keys(req.body).forEach(key => {
+        if (!userFields.includes(key)) {
+          profileData[key] = req.body[key];
+        }
+      });
+
+      const technician = await userService.createUser(userData, profileData);
 
       res.status(201).json({
         success: true,
@@ -94,7 +112,14 @@ class TechnicianController {
         });
       }
 
-      const updatedTechnician = await userService.updateUser(req.params.id, req.body);
+      const { name, phone, profilePicture, ...profileData } = req.body;
+      
+      const userData = {};
+      if (name !== undefined) userData.name = name;
+      if (phone !== undefined) userData.phone = phone;
+      if (profilePicture !== undefined) userData.profilePicture = profilePicture;
+
+      const updatedTechnician = await userService.updateUser(req.params.id, userData, profileData);
 
       res.status(200).json({
         success: true,

--- a/src/database/migrations/20251012000000-create-technicians-table.cjs
+++ b/src/database/migrations/20251012000000-create-technicians-table.cjs
@@ -1,0 +1,85 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Technicians', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      specialization: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        comment: 'Technical specialization area (e.g., Electrical, Mechanical, Software)'
+      },
+      experienceYears: {
+        type: Sequelize.INTEGER,
+        allowNull: true
+      },
+      certification: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        comment: 'Professional certifications'
+      },
+      employeeId: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        unique: true,
+        comment: 'Company employee ID'
+      },
+      isAvailable: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false,
+        defaultValue: true,
+        comment: 'Availability status for task assignment'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Add indexes
+    await queryInterface.addIndex('Technicians', ['userId'], {
+      unique: true,
+      name: 'technicians_user_id_unique'
+    });
+
+    await queryInterface.addIndex('Technicians', ['employeeId'], {
+      unique: true,
+      name: 'technicians_employee_id_unique'
+    });
+
+    await queryInterface.addIndex('Technicians', ['specialization'], {
+      name: 'technicians_specialization_index'
+    });
+
+    await queryInterface.addIndex('Technicians', ['isAvailable'], {
+      name: 'technicians_is_available_index'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('Technicians');
+  }
+};

--- a/src/database/migrations/20251012000001-create-branch-managers-table.cjs
+++ b/src/database/migrations/20251012000001-create-branch-managers-table.cjs
@@ -1,0 +1,90 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('BranchManagers', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      branchId: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        comment: 'Branch identifier code'
+      },
+      branchName: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+        comment: 'Name of the branch managed'
+      },
+      region: {
+        type: Sequelize.STRING(100),
+        allowNull: true,
+        comment: 'Geographic region (e.g., Western, Central, Southern)'
+      },
+      employeeId: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        unique: true,
+        comment: 'Company employee ID'
+      },
+      managementLevel: {
+        type: Sequelize.ENUM('junior', 'senior', 'regional'),
+        allowNull: false,
+        defaultValue: 'junior',
+        comment: 'Management hierarchy level'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Add indexes
+    await queryInterface.addIndex('BranchManagers', ['userId'], {
+      unique: true,
+      name: 'branch_managers_user_id_unique'
+    });
+
+    await queryInterface.addIndex('BranchManagers', ['employeeId'], {
+      unique: true,
+      name: 'branch_managers_employee_id_unique'
+    });
+
+    await queryInterface.addIndex('BranchManagers', ['branchId'], {
+      name: 'branch_managers_branch_id_index'
+    });
+
+    await queryInterface.addIndex('BranchManagers', ['region'], {
+      name: 'branch_managers_region_index'
+    });
+
+    await queryInterface.addIndex('BranchManagers', ['managementLevel'], {
+      name: 'branch_managers_management_level_index'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('BranchManagers');
+  }
+};

--- a/src/database/migrations/20251012000002-create-maintenance-executives-table.cjs
+++ b/src/database/migrations/20251012000002-create-maintenance-executives-table.cjs
@@ -1,0 +1,91 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('MaintenanceExecutives', {
+      id: {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+        allowNull: false
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        unique: true,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
+      },
+      department: {
+        type: Sequelize.STRING(100),
+        allowNull: true,
+        comment: 'Department name (e.g., Operations, Facilities, Equipment)'
+      },
+      level: {
+        type: Sequelize.ENUM('executive', 'senior_executive', 'chief'),
+        allowNull: false,
+        defaultValue: 'executive',
+        comment: 'Executive hierarchy level'
+      },
+      employeeId: {
+        type: Sequelize.STRING(50),
+        allowNull: true,
+        unique: true,
+        comment: 'Company employee ID'
+      },
+      responsibilities: {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        comment: 'Key areas of responsibility'
+      },
+      authorityLevel: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+        comment: 'Decision-making authority level (1-5)'
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP')
+      }
+    });
+
+    // Add indexes
+    await queryInterface.addIndex('MaintenanceExecutives', ['userId'], {
+      unique: true,
+      name: 'maintenance_executives_user_id_unique'
+    });
+
+    await queryInterface.addIndex('MaintenanceExecutives', ['employeeId'], {
+      unique: true,
+      name: 'maintenance_executives_employee_id_unique'
+    });
+
+    await queryInterface.addIndex('MaintenanceExecutives', ['department'], {
+      name: 'maintenance_executives_department_index'
+    });
+
+    await queryInterface.addIndex('MaintenanceExecutives', ['level'], {
+      name: 'maintenance_executives_level_index'
+    });
+
+    await queryInterface.addIndex('MaintenanceExecutives', ['authorityLevel'], {
+      name: 'maintenance_executives_authority_level_index'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.dropTable('MaintenanceExecutives');
+  }
+};

--- a/src/database/migrations/20251013000000-update-technicians-table.cjs
+++ b/src/database/migrations/20251013000000-update-technicians-table.cjs
@@ -1,0 +1,34 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Add location_id field
+    await queryInterface.addColumn('Technicians', 'location_id', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      comment: 'Location/area the technician covers'
+    });
+
+    // Add index for location_id
+    await queryInterface.addIndex('Technicians', ['location_id'], {
+      name: 'technicians_location_id_idx'
+    });
+
+    // Remove certification field (not essential)
+    await queryInterface.removeColumn('Technicians', 'certification');
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Remove location_id field
+    await queryInterface.removeIndex('Technicians', 'technicians_location_id_idx');
+    await queryInterface.removeColumn('Technicians', 'location_id');
+
+    // Add back certification field
+    await queryInterface.addColumn('Technicians', 'certification', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+      comment: 'Professional certifications'
+    });
+  }
+};

--- a/src/database/migrations/20251013000001-update-branch-managers-table.cjs
+++ b/src/database/migrations/20251013000001-update-branch-managers-table.cjs
@@ -1,0 +1,77 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // First, set all branchId values to NULL
+    await queryInterface.sequelize.query(
+      'UPDATE "BranchManagers" SET "branchId" = NULL'
+    );
+
+    // Change branchId from STRING to INTEGER using raw SQL
+    await queryInterface.sequelize.query(
+      'ALTER TABLE "BranchManagers" ALTER COLUMN "branchId" TYPE INTEGER USING "branchId"::integer'
+    );
+    
+    // Add comment
+    await queryInterface.sequelize.query(
+      `COMMENT ON COLUMN "BranchManagers"."branchId" IS 'Branch identifier - references Branch table'`
+    );
+
+    // Remove unnecessary fields
+    await queryInterface.removeColumn('BranchManagers', 'branchName');
+    await queryInterface.removeColumn('BranchManagers', 'region');
+    await queryInterface.removeColumn('BranchManagers', 'managementLevel');
+
+    // Remove old indexes (using correct names from original migration)
+    await queryInterface.removeIndex('BranchManagers', 'branch_managers_branch_id_index');
+    await queryInterface.removeIndex('BranchManagers', 'branch_managers_region_index');
+    await queryInterface.removeIndex('BranchManagers', 'branch_managers_management_level_index');
+
+    // Add new index for INTEGER branchId
+    await queryInterface.addIndex('BranchManagers', ['branchId'], {
+      name: 'branch_managers_branch_id_index'
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Change branchId back to STRING
+    await queryInterface.changeColumn('BranchManagers', 'branchId', {
+      type: Sequelize.STRING(50),
+      allowNull: true,
+      comment: 'Branch identifier code'
+    });
+
+    // Add back removed fields
+    await queryInterface.addColumn('BranchManagers', 'branchName', {
+      type: Sequelize.STRING(255),
+      allowNull: true,
+      comment: 'Name of the branch managed'
+    });
+
+    await queryInterface.addColumn('BranchManagers', 'region', {
+      type: Sequelize.STRING(100),
+      allowNull: true,
+      comment: 'Geographic region'
+    });
+
+    await queryInterface.addColumn('BranchManagers', 'managementLevel', {
+      type: Sequelize.ENUM('junior', 'senior', 'regional'),
+      allowNull: false,
+      defaultValue: 'junior',
+      comment: 'Management hierarchy level'
+    });
+
+    // Restore old indexes
+    await queryInterface.removeIndex('BranchManagers', 'branch_managers_branch_id_index');
+    await queryInterface.addIndex('BranchManagers', ['branchId'], {
+      name: 'branch_managers_branch_id_index'
+    });
+    await queryInterface.addIndex('BranchManagers', ['region'], {
+      name: 'branch_managers_region_index'
+    });
+    await queryInterface.addIndex('BranchManagers', ['managementLevel'], {
+      name: 'branch_managers_management_level_index'
+    });
+  }
+};

--- a/src/database/migrations/20251013000002-update-maintenance-executives-table.cjs
+++ b/src/database/migrations/20251013000002-update-maintenance-executives-table.cjs
@@ -1,0 +1,45 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // Remove unnecessary fields - keep only userId and employeeId
+    await queryInterface.removeColumn('MaintenanceExecutives', 'department');
+    await queryInterface.removeColumn('MaintenanceExecutives', 'level');
+    await queryInterface.removeColumn('MaintenanceExecutives', 'responsibilities');
+    await queryInterface.removeColumn('MaintenanceExecutives', 'authorityLevel');
+  },
+
+  async down(queryInterface, Sequelize) {
+    // Add back removed fields
+    await queryInterface.addColumn('MaintenanceExecutives', 'department', {
+      type: Sequelize.STRING(100),
+      allowNull: true,
+      comment: 'Department the executive oversees'
+    });
+
+    await queryInterface.addColumn('MaintenanceExecutives', 'level', {
+      type: Sequelize.ENUM('executive', 'senior_executive', 'chief'),
+      allowNull: false,
+      defaultValue: 'executive',
+      comment: 'Executive hierarchy level'
+    });
+
+    await queryInterface.addColumn('MaintenanceExecutives', 'responsibilities', {
+      type: Sequelize.TEXT,
+      allowNull: true,
+      comment: 'Detailed responsibilities and scope'
+    });
+
+    await queryInterface.addColumn('MaintenanceExecutives', 'authorityLevel', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+      validate: {
+        min: 1,
+        max: 5
+      },
+      comment: 'Authority level from 1 (lowest) to 5 (highest)'
+    });
+  }
+};

--- a/src/database/seeders/20251012000000-demo-role-profiles.cjs
+++ b/src/database/seeders/20251012000000-demo-role-profiles.cjs
@@ -1,0 +1,111 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    // First, get the user IDs that were created in the user seeder
+    // We'll create profiles for the users that exist
+    
+    // Get all technician users
+    const technicians = await queryInterface.sequelize.query(
+      `SELECT id FROM "Users" WHERE role = 'technician' AND "isActive" = true ORDER BY id LIMIT 2`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
+
+    // Get all branch manager users
+    const branchManagers = await queryInterface.sequelize.query(
+      `SELECT id FROM "Users" WHERE role = 'branch_manager' AND "isActive" = true ORDER BY id LIMIT 2`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
+
+    // Get all maintenance executive users
+    const executives = await queryInterface.sequelize.query(
+      `SELECT id FROM "Users" WHERE role = 'maintenance_executive' AND "isActive" = true ORDER BY id LIMIT 2`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
+
+    // Seed Technician profiles
+    if (technicians.length > 0) {
+      await queryInterface.bulkInsert('Technicians', [
+        {
+          userId: technicians[0].id,
+          specialization: 'Electrical Systems',
+          experienceYears: 5,
+          certification: 'Licensed Electrician',
+          employeeId: 'TECH-001',
+          isAvailable: true,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        technicians.length > 1 ? {
+          userId: technicians[1].id,
+          specialization: 'Mechanical Engineering',
+          experienceYears: 3,
+          certification: 'Certified Mechanic',
+          employeeId: 'TECH-002',
+          isAvailable: true,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        } : null
+      ].filter(Boolean));
+    }
+
+    // Seed Branch Manager profiles
+    if (branchManagers.length > 0) {
+      await queryInterface.bulkInsert('BranchManagers', [
+        {
+          userId: branchManagers[0].id,
+          branchId: 'BR-COLOMBO-01',
+          branchName: 'Colombo Main Branch',
+          region: 'Western Province',
+          employeeId: 'MGR-001',
+          managementLevel: 'senior',
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        branchManagers.length > 1 ? {
+          userId: branchManagers[1].id,
+          branchId: 'BR-KANDY-01',
+          branchName: 'Kandy Branch',
+          region: 'Central Province',
+          employeeId: 'MGR-002',
+          managementLevel: 'junior',
+          createdAt: new Date(),
+          updatedAt: new Date()
+        } : null
+      ].filter(Boolean));
+    }
+
+    // Seed Maintenance Executive profiles
+    if (executives.length > 0) {
+      await queryInterface.bulkInsert('MaintenanceExecutives', [
+        {
+          userId: executives[0].id,
+          department: 'Operations',
+          level: 'senior_executive',
+          employeeId: 'EXEC-001',
+          responsibilities: 'Oversee all maintenance operations and ensure compliance',
+          authorityLevel: 4,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        executives.length > 1 ? {
+          userId: executives[1].id,
+          department: 'Facilities Management',
+          level: 'executive',
+          employeeId: 'EXEC-002',
+          responsibilities: 'Manage facility maintenance and vendor relationships',
+          authorityLevel: 2,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        } : null
+      ].filter(Boolean));
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.bulkDelete('Technicians', null, {});
+    await queryInterface.bulkDelete('BranchManagers', null, {});
+    await queryInterface.bulkDelete('MaintenanceExecutives', null, {});
+  }
+};

--- a/src/database/seeders/20251012000000-demo-role-profiles.cjs
+++ b/src/database/seeders/20251012000000-demo-role-profiles.cjs
@@ -31,7 +31,6 @@ module.exports = {
           userId: technicians[0].id,
           specialization: 'Electrical Systems',
           experienceYears: 5,
-          certification: 'Licensed Electrician',
           employeeId: 'TECH-001',
           isAvailable: true,
           createdAt: new Date(),
@@ -41,7 +40,6 @@ module.exports = {
           userId: technicians[1].id,
           specialization: 'Mechanical Engineering',
           experienceYears: 3,
-          certification: 'Certified Mechanic',
           employeeId: 'TECH-002',
           isAvailable: true,
           createdAt: new Date(),
@@ -55,21 +53,15 @@ module.exports = {
       await queryInterface.bulkInsert('BranchManagers', [
         {
           userId: branchManagers[0].id,
-          branchId: 'BR-COLOMBO-01',
-          branchName: 'Colombo Main Branch',
-          region: 'Western Province',
+          branchId: '01',
           employeeId: 'MGR-001',
-          managementLevel: 'senior',
           createdAt: new Date(),
           updatedAt: new Date()
         },
         branchManagers.length > 1 ? {
           userId: branchManagers[1].id,
-          branchId: 'BR-KANDY-01',
-          branchName: 'Kandy Branch',
-          region: 'Central Province',
+          branchId: '02',
           employeeId: 'MGR-002',
-          managementLevel: 'junior',
           createdAt: new Date(),
           updatedAt: new Date()
         } : null
@@ -81,21 +73,13 @@ module.exports = {
       await queryInterface.bulkInsert('MaintenanceExecutives', [
         {
           userId: executives[0].id,
-          department: 'Operations',
-          level: 'senior_executive',
           employeeId: 'EXEC-001',
-          responsibilities: 'Oversee all maintenance operations and ensure compliance',
-          authorityLevel: 4,
           createdAt: new Date(),
           updatedAt: new Date()
         },
         executives.length > 1 ? {
           userId: executives[1].id,
-          department: 'Facilities Management',
-          level: 'executive',
           employeeId: 'EXEC-002',
-          responsibilities: 'Manage facility maintenance and vendor relationships',
-          authorityLevel: 2,
           createdAt: new Date(),
           updatedAt: new Date()
         } : null

--- a/src/middleware/upload.js
+++ b/src/middleware/upload.js
@@ -1,0 +1,58 @@
+import multer from 'multer';
+
+/**
+ * Multer configuration for profile picture uploads
+ */
+
+// File filter - only allow images
+const fileFilter = (req, file, cb) => {
+  const allowedMimeTypes = [
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/gif',
+    'image/webp'
+  ];
+
+  if (allowedMimeTypes.includes(file.mimetype)) {
+    cb(null, true);
+  } else {
+    cb(new Error('Invalid file type. Only JPEG, PNG, GIF, and WebP images are allowed.'), false);
+  }
+};
+
+// Multer configuration - store in memory
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 5 * 1024 * 1024, // 5MB max file size
+  },
+  fileFilter: fileFilter
+});
+
+// Middleware for single file upload (field name: 'profilePicture')
+export const uploadProfilePicture = upload.single('profilePicture');
+
+// Error handler middleware for multer errors
+export const handleUploadError = (err, req, res, next) => {
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({
+        error: 'File too large. Maximum size is 5MB.'
+      });
+    }
+    return res.status(400).json({
+      error: `Upload error: ${err.message}`
+    });
+  } else if (err) {
+    return res.status(400).json({
+      error: err.message
+    });
+  }
+  next();
+};
+
+export default {
+  uploadProfilePicture,
+  handleUploadError
+};

--- a/src/models/branchManager.js
+++ b/src/models/branchManager.js
@@ -1,0 +1,84 @@
+import { DataTypes } from 'sequelize';
+import { getSequelizeInstance } from '../services/connectionService.js';
+
+const sequelize = getSequelizeInstance();
+
+const BranchManager = sequelize.define(
+  'BranchManager',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+      validate: {
+        notNull: {
+          msg: 'User ID is required'
+        }
+      }
+    },
+    branchId: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      comment: 'Branch identifier code'
+    },
+    branchName: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      comment: 'Name of the branch managed'
+    },
+    region: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+      comment: 'Geographic region (e.g., Western, Central, Southern)'
+    },
+    employeeId: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      unique: true,
+      comment: 'Company employee ID'
+    },
+    managementLevel: {
+      type: DataTypes.ENUM('junior', 'senior', 'regional'),
+      allowNull: false,
+      defaultValue: 'junior',
+      comment: 'Management hierarchy level'
+    }
+  },
+  {
+    tableName: 'BranchManagers',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['userId']
+      },
+      {
+        unique: true,
+        fields: ['employeeId']
+      },
+      {
+        fields: ['branchId']
+      },
+      {
+        fields: ['region']
+      },
+      {
+        fields: ['managementLevel']
+      }
+    ]
+  }
+);
+
+export default BranchManager;

--- a/src/models/branchManager.js
+++ b/src/models/branchManager.js
@@ -29,31 +29,15 @@ const BranchManager = sequelize.define(
       }
     },
     branchId: {
-      type: DataTypes.STRING(50),
+      type: DataTypes.INTEGER,
       allowNull: true,
-      comment: 'Branch identifier code'
-    },
-    branchName: {
-      type: DataTypes.STRING(255),
-      allowNull: true,
-      comment: 'Name of the branch managed'
-    },
-    region: {
-      type: DataTypes.STRING(100),
-      allowNull: true,
-      comment: 'Geographic region (e.g., Western, Central, Southern)'
+      comment: 'Branch identifier - references Branch table'
     },
     employeeId: {
       type: DataTypes.STRING(50),
       allowNull: true,
       unique: true,
       comment: 'Company employee ID'
-    },
-    managementLevel: {
-      type: DataTypes.ENUM('junior', 'senior', 'regional'),
-      allowNull: false,
-      defaultValue: 'junior',
-      comment: 'Management hierarchy level'
     }
   },
   {
@@ -70,14 +54,12 @@ const BranchManager = sequelize.define(
       },
       {
         fields: ['branchId']
-      },
-      {
-        fields: ['region']
-      },
-      {
-        fields: ['managementLevel']
       }
-    ]
+    ],
+    // Remove userId from JSON responses to avoid duplication
+    defaultScope: {
+      attributes: { exclude: ['userId'] }
+    }
   }
 );
 

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,13 +1,58 @@
 import { getSequelizeInstance } from '../services/connectionService.js';
 import Issue from './issue.js';
 import User from './user.js';
+import Technician from './technician.js';
+import BranchManager from './branchManager.js';
+import MaintenanceExecutive from './maintenanceExecutive.js';
 
 const sequelize = getSequelizeInstance();
+
+// Define associations between User and role-specific tables
+// One User can have one role-specific record
+User.hasOne(Technician, {
+  foreignKey: 'userId',
+  as: 'technicianProfile',
+  onDelete: 'CASCADE'
+});
+
+User.hasOne(BranchManager, {
+  foreignKey: 'userId',
+  as: 'branchManagerProfile',
+  onDelete: 'CASCADE'
+});
+
+User.hasOne(MaintenanceExecutive, {
+  foreignKey: 'userId',
+  as: 'maintenanceExecutiveProfile',
+  onDelete: 'CASCADE'
+});
+
+// Inverse relationships - each role belongs to one User
+Technician.belongsTo(User, {
+  foreignKey: 'userId',
+  as: 'user',
+  onDelete: 'CASCADE'
+});
+
+BranchManager.belongsTo(User, {
+  foreignKey: 'userId',
+  as: 'user',
+  onDelete: 'CASCADE'
+});
+
+MaintenanceExecutive.belongsTo(User, {
+  foreignKey: 'userId',
+  as: 'user',
+  onDelete: 'CASCADE'
+});
 
 // Initialize all models
 const models = {
   Issue,
   User,
+  Technician,
+  BranchManager,
+  MaintenanceExecutive,
   sequelize
 };
 
@@ -15,7 +60,7 @@ const models = {
 // For example:
 // Issue.belongsTo(User, { foreignKey: 'userid' });
 // Issue.belongsTo(Branch, { foreignKey: 'branch_id' });
-// Note: No relationships defined yet to avoid conflicts during development
+// Note: User-role relationships are now defined above
 
 export default models;
-export { Issue, User, sequelize };
+export { Issue, User, Technician, BranchManager, MaintenanceExecutive, sequelize };

--- a/src/models/maintenanceExecutive.js
+++ b/src/models/maintenanceExecutive.js
@@ -28,43 +28,11 @@ const MaintenanceExecutive = sequelize.define(
         }
       }
     },
-    department: {
-      type: DataTypes.STRING(100),
-      allowNull: true,
-      comment: 'Department name (e.g., Operations, Facilities, Equipment)'
-    },
-    level: {
-      type: DataTypes.ENUM('executive', 'senior_executive', 'chief'),
-      allowNull: false,
-      defaultValue: 'executive',
-      comment: 'Executive hierarchy level'
-    },
     employeeId: {
       type: DataTypes.STRING(50),
       allowNull: true,
       unique: true,
       comment: 'Company employee ID'
-    },
-    responsibilities: {
-      type: DataTypes.TEXT,
-      allowNull: true,
-      comment: 'Key areas of responsibility'
-    },
-    authorityLevel: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      defaultValue: 1,
-      validate: {
-        min: {
-          args: [1],
-          msg: 'Authority level must be at least 1'
-        },
-        max: {
-          args: [5],
-          msg: 'Authority level cannot exceed 5'
-        }
-      },
-      comment: 'Decision-making authority level (1-5)'
     }
   },
   {
@@ -78,17 +46,12 @@ const MaintenanceExecutive = sequelize.define(
       {
         unique: true,
         fields: ['employeeId']
-      },
-      {
-        fields: ['department']
-      },
-      {
-        fields: ['level']
-      },
-      {
-        fields: ['authorityLevel']
       }
-    ]
+    ],
+    // Remove userId from JSON responses to avoid duplication
+    defaultScope: {
+      attributes: { exclude: ['userId'] }
+    }
   }
 );
 

--- a/src/models/maintenanceExecutive.js
+++ b/src/models/maintenanceExecutive.js
@@ -1,0 +1,95 @@
+import { DataTypes } from 'sequelize';
+import { getSequelizeInstance } from '../services/connectionService.js';
+
+const sequelize = getSequelizeInstance();
+
+const MaintenanceExecutive = sequelize.define(
+  'MaintenanceExecutive',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+      validate: {
+        notNull: {
+          msg: 'User ID is required'
+        }
+      }
+    },
+    department: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+      comment: 'Department name (e.g., Operations, Facilities, Equipment)'
+    },
+    level: {
+      type: DataTypes.ENUM('executive', 'senior_executive', 'chief'),
+      allowNull: false,
+      defaultValue: 'executive',
+      comment: 'Executive hierarchy level'
+    },
+    employeeId: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      unique: true,
+      comment: 'Company employee ID'
+    },
+    responsibilities: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      comment: 'Key areas of responsibility'
+    },
+    authorityLevel: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+      validate: {
+        min: {
+          args: [1],
+          msg: 'Authority level must be at least 1'
+        },
+        max: {
+          args: [5],
+          msg: 'Authority level cannot exceed 5'
+        }
+      },
+      comment: 'Decision-making authority level (1-5)'
+    }
+  },
+  {
+    tableName: 'MaintenanceExecutives',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['userId']
+      },
+      {
+        unique: true,
+        fields: ['employeeId']
+      },
+      {
+        fields: ['department']
+      },
+      {
+        fields: ['level']
+      },
+      {
+        fields: ['authorityLevel']
+      }
+    ]
+  }
+);
+
+export default MaintenanceExecutive;

--- a/src/models/technician.js
+++ b/src/models/technician.js
@@ -1,0 +1,86 @@
+import { DataTypes } from 'sequelize';
+import { getSequelizeInstance } from '../services/connectionService.js';
+
+const sequelize = getSequelizeInstance();
+
+const Technician = sequelize.define(
+  'Technician',
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+      allowNull: false
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      unique: true,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE',
+      validate: {
+        notNull: {
+          msg: 'User ID is required'
+        }
+      }
+    },
+    specialization: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      comment: 'Technical specialization area (e.g., Electrical, Mechanical, Software)'
+    },
+    experienceYears: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      validate: {
+        min: {
+          args: [0],
+          msg: 'Experience years cannot be negative'
+        }
+      }
+    },
+    certification: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+      comment: 'Professional certifications'
+    },
+    employeeId: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
+      unique: true,
+      comment: 'Company employee ID'
+    },
+    isAvailable: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+      comment: 'Availability status for task assignment'
+    }
+  },
+  {
+    tableName: 'Technicians',
+    timestamps: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ['userId']
+      },
+      {
+        unique: true,
+        fields: ['employeeId']
+      },
+      {
+        fields: ['specialization']
+      },
+      {
+        fields: ['isAvailable']
+      }
+    ]
+  }
+);
+
+export default Technician;

--- a/src/models/technician.js
+++ b/src/models/technician.js
@@ -55,7 +55,7 @@ const Technician = sequelize.define(
       defaultValue: true,
       comment: 'Availability status for task assignment'
     },
-    locationId: {
+    location_id: {
       type: DataTypes.INTEGER,
       allowNull: true,
       comment: 'Location/area the technician covers'
@@ -80,7 +80,7 @@ const Technician = sequelize.define(
         fields: ['isAvailable']
       },
       {
-        fields: ['locationId']
+        fields: ['location_id']
       }
     ],
     // Remove userId from JSON responses to avoid duplication

--- a/src/models/technician.js
+++ b/src/models/technician.js
@@ -43,11 +43,6 @@ const Technician = sequelize.define(
         }
       }
     },
-    certification: {
-      type: DataTypes.STRING(255),
-      allowNull: true,
-      comment: 'Professional certifications'
-    },
     employeeId: {
       type: DataTypes.STRING(50),
       allowNull: true,
@@ -59,6 +54,11 @@ const Technician = sequelize.define(
       allowNull: false,
       defaultValue: true,
       comment: 'Availability status for task assignment'
+    },
+    location_id: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      comment: 'Location/area the technician covers'
     }
   },
   {
@@ -78,8 +78,15 @@ const Technician = sequelize.define(
       },
       {
         fields: ['isAvailable']
+      },
+      {
+        fields: ['location_id']
       }
-    ]
+    ],
+    // Remove userId from JSON responses to avoid duplication
+    defaultScope: {
+      attributes: { exclude: ['userId'] }
+    }
   }
 );
 

--- a/src/models/technician.js
+++ b/src/models/technician.js
@@ -55,7 +55,7 @@ const Technician = sequelize.define(
       defaultValue: true,
       comment: 'Availability status for task assignment'
     },
-    location_id: {
+    locationId: {
       type: DataTypes.INTEGER,
       allowNull: true,
       comment: 'Location/area the technician covers'
@@ -80,7 +80,7 @@ const Technician = sequelize.define(
         fields: ['isAvailable']
       },
       {
-        fields: ['location_id']
+        fields: ['locationId']
       }
     ],
     // Remove userId from JSON responses to avoid duplication

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -95,4 +95,8 @@ const User = sequelize.define(
   }
 );
 
+// Define associations
+// Note: The actual association setup happens in src/models/index.js
+// to avoid circular dependency issues
+
 export default User;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -8,6 +8,7 @@ import {
   validateUpdateUser,
   validateUserId
 } from '../middleware/validation.js';
+import { uploadProfilePicture, handleUploadError } from '../middleware/upload.js';
 
 const router = express.Router();
 
@@ -20,7 +21,7 @@ const router = express.Router();
  * @desc    Create a new technician
  * @access  Public (no auth for now)
  */
-router.post('/technicians', validateCreateUser, technicianController.createTechnician);
+router.post('/technicians', uploadProfilePicture, handleUploadError, validateCreateUser, technicianController.createTechnician);
 
 /**
  * @route   GET /api/v1/users/technicians
@@ -43,6 +44,8 @@ router.get('/technicians/:id', validateUserId, technicianController.getTechnicia
  */
 router.put(
   '/technicians/:id',
+  uploadProfilePicture,
+  handleUploadError,
   validateUserId,
   validateUpdateUser,
   technicianController.updateTechnician
@@ -64,7 +67,7 @@ router.delete('/technicians/:id', validateUserId, technicianController.deleteTec
  * @desc    Create a new branch manager
  * @access  Public
  */
-router.post('/branch-managers', validateCreateUser, branchManagerController.createBranchManager);
+router.post('/branch-managers', uploadProfilePicture, handleUploadError, validateCreateUser, branchManagerController.createBranchManager);
 
 /**
  * @route   GET /api/v1/users/branch-managers
@@ -87,6 +90,8 @@ router.get('/branch-managers/:id', validateUserId, branchManagerController.getBr
  */
 router.put(
   '/branch-managers/:id',
+  uploadProfilePicture,
+  handleUploadError,
   validateUserId,
   validateUpdateUser,
   branchManagerController.updateBranchManager
@@ -110,6 +115,8 @@ router.delete('/branch-managers/:id', validateUserId, branchManagerController.de
  */
 router.post(
   '/maintenance-executives',
+  uploadProfilePicture,
+  handleUploadError,
   validateCreateUser,
   maintenanceExecutiveController.createMaintenanceExecutive
 );
@@ -139,6 +146,8 @@ router.get(
  */
 router.put(
   '/maintenance-executives/:id',
+  uploadProfilePicture,
+  handleUploadError,
   validateUserId,
   validateUpdateUser,
   maintenanceExecutiveController.updateMaintenanceExecutive

--- a/src/services/uploadService.js
+++ b/src/services/uploadService.js
@@ -1,0 +1,110 @@
+import minioClient from '../config/minio.js';
+import crypto from 'crypto';
+import path from 'path';
+
+/**
+ * Upload Service for MinIO file uploads
+ */
+
+const BUCKET_NAME = 'profile-pictures';
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT || 'localhost:9000';
+
+/**
+ * Ensure bucket exists, create if not
+ */
+const ensureBucketExists = async () => {
+  try {
+    const bucketExists = await minioClient.bucketExists(BUCKET_NAME);
+    
+    if (!bucketExists) {
+      await minioClient.makeBucket(BUCKET_NAME, 'us-east-1');
+      console.log(`✅ Bucket "${BUCKET_NAME}" created successfully`);
+      
+      // Set bucket policy to allow public read access
+      const policy = {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { AWS: ['*'] },
+            Action: ['s3:GetObject'],
+            Resource: [`arn:aws:s3:::${BUCKET_NAME}/*`]
+          }
+        ]
+      };
+      
+      await minioClient.setBucketPolicy(BUCKET_NAME, JSON.stringify(policy));
+    }
+    
+    return true;
+  } catch (error) {
+    console.error('Error ensuring bucket exists:', error);
+    throw new Error('Failed to initialize storage bucket');
+  }
+};
+
+/**
+ * Upload file to MinIO
+ * @param {Buffer} fileBuffer - File buffer from multer
+ * @param {string} originalName - Original filename
+ * @param {string} mimeType - File MIME type
+ * @returns {Promise<string>} - MinIO file URL
+ */
+export const uploadProfilePicture = async (fileBuffer, originalName, mimeType) => {
+  try {
+    // Ensure bucket exists
+    await ensureBucketExists();
+    
+    // Generate unique filename
+    const fileExtension = path.extname(originalName);
+    const uniqueFileName = `${crypto.randomUUID()}${fileExtension}`;
+    
+    // Upload to MinIO
+    await minioClient.putObject(
+      BUCKET_NAME,
+      uniqueFileName,
+      fileBuffer,
+      fileBuffer.length,
+      {
+        'Content-Type': mimeType,
+        'x-amz-meta-original-name': originalName
+      }
+    );
+    
+    // Generate public URL
+    const fileUrl = `http://${MINIO_ENDPOINT}/${BUCKET_NAME}/${uniqueFileName}`;
+    
+    console.log(`✅ File uploaded successfully: ${fileUrl}`);
+    return fileUrl;
+    
+  } catch (error) {
+    console.error('MinIO upload error:', error);
+    throw new Error('Failed to upload file to storage');
+  }
+};
+
+/**
+ * Delete file from MinIO
+ * @param {string} fileUrl - MinIO file URL
+ */
+export const deleteProfilePicture = async (fileUrl) => {
+  try {
+    if (!fileUrl) return;
+    
+    // Extract filename from URL
+    const urlParts = fileUrl.split('/');
+    const fileName = urlParts[urlParts.length - 1];
+    
+    await minioClient.removeObject(BUCKET_NAME, fileName);
+    console.log(`✅ File deleted successfully: ${fileName}`);
+    
+  } catch (error) {
+    console.error('MinIO delete error:', error);
+    // Don't throw error - deletion is best effort
+  }
+};
+
+export default {
+  uploadProfilePicture,
+  deleteProfilePicture
+};

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,34 +1,88 @@
-import User from '../models/user.js';
+import { User, Technician, BranchManager, MaintenanceExecutive } from '../models/index.js';
+import { getSequelizeInstance } from './connectionService.js';
+
+const sequelize = getSequelizeInstance();
 
 /**
  * User Service - Contains all business logic for user operations
  * Handles CRUD operations for technicians, branch managers, and maintenance executives
+ * Now with support for role-specific profile tables and relationships
  */
 class UserService {
   /**
-   * Create a new user
-   * @param {Object} userData - User data
-   * @returns {Promise<Object>} Created user
+   * Create a new user with role-specific profile
+   * @param {Object} userData - User data (basic info)
+   * @param {Object} profileData - Role-specific profile data
+   * @returns {Promise<Object>} Created user with profile
    */
-  async createUser(userData) {
+  async createUser(userData, profileData = {}) {
+    const transaction = await sequelize.transaction();
+    
     try {
-      const user = await User.create(userData);
-      // Don't return password in response
-      const userResponse = user.toJSON();
-      delete userResponse.password;
-      return userResponse;
+      // Create base user
+      const user = await User.create(userData, { transaction });
+      
+      // Create role-specific profile based on user role
+      let profile = null;
+      if (userData.role === 'technician') {
+        profile = await Technician.create({
+          userId: user.id,
+          ...profileData
+        }, { transaction });
+      } else if (userData.role === 'branch_manager') {
+        profile = await BranchManager.create({
+          userId: user.id,
+          ...profileData
+        }, { transaction });
+      } else if (userData.role === 'maintenance_executive') {
+        profile = await MaintenanceExecutive.create({
+          userId: user.id,
+          ...profileData
+        }, { transaction });
+      }
+
+      await transaction.commit();
+
+      // Fetch complete user with profile (outside transaction)
+      const completeUser = await User.findOne({
+        where: { id: user.id },
+        attributes: { exclude: ['password'] },
+        include: [
+          {
+            model: Technician,
+            as: 'technicianProfile',
+            required: false
+          },
+          {
+            model: BranchManager,
+            as: 'branchManagerProfile',
+            required: false
+          },
+          {
+            model: MaintenanceExecutive,
+            as: 'maintenanceExecutiveProfile',
+            required: false
+          }
+        ]
+      });
+
+      return completeUser;
     } catch (error) {
+      // Only rollback if transaction hasn't been committed
+      if (!transaction.finished) {
+        await transaction.rollback();
+      }
       if (error.name === 'SequelizeUniqueConstraintError') {
-        throw new Error('Email already exists');
+        throw new Error('Email or employee ID already exists');
       }
       throw error;
     }
   }
 
   /**
-   * Get all users, optionally filtered by role
+   * Get all users with their profiles, optionally filtered by role
    * @param {string} role - Optional role filter
-   * @returns {Promise<Array>} List of users
+   * @returns {Promise<Array>} List of users with profiles
    */
   async getAllUsers(role = null) {
     const where = { isActive: true };
@@ -39,6 +93,23 @@ class UserService {
     const users = await User.findAll({
       where,
       attributes: { exclude: ['password'] },
+      include: [
+        {
+          model: Technician,
+          as: 'technicianProfile',
+          required: false
+        },
+        {
+          model: BranchManager,
+          as: 'branchManagerProfile',
+          required: false
+        },
+        {
+          model: MaintenanceExecutive,
+          as: 'maintenanceExecutiveProfile',
+          required: false
+        }
+      ],
       order: [['createdAt', 'DESC']]
     });
 
@@ -46,14 +117,31 @@ class UserService {
   }
 
   /**
-   * Get user by ID
+   * Get user by ID with profile
    * @param {number} userId - User ID
-   * @returns {Promise<Object>} User object
+   * @returns {Promise<Object>} User object with profile
    */
   async getUserById(userId) {
     const user = await User.findOne({
       where: { id: userId, isActive: true },
-      attributes: { exclude: ['password'] }
+      attributes: { exclude: ['password'] },
+      include: [
+        {
+          model: Technician,
+          as: 'technicianProfile',
+          required: false
+        },
+        {
+          model: BranchManager,
+          as: 'branchManagerProfile',
+          required: false
+        },
+        {
+          model: MaintenanceExecutive,
+          as: 'maintenanceExecutiveProfile',
+          required: false
+        }
+      ]
     });
 
     if (!user) {
@@ -64,34 +152,68 @@ class UserService {
   }
 
   /**
-   * Update user by ID
+   * Update user and/or profile by ID
    * @param {number} userId - User ID
-   * @param {Object} updateData - Data to update
-   * @returns {Promise<Object>} Updated user
+   * @param {Object} updateData - Data to update (user fields)
+   * @param {Object} profileData - Profile data to update (role-specific fields)
+   * @returns {Promise<Object>} Updated user with profile
    */
-  async updateUser(userId, updateData) {
-    const user = await User.findOne({
-      where: { id: userId, isActive: true }
-    });
+  async updateUser(userId, updateData, profileData = {}) {
+    const transaction = await sequelize.transaction();
+    
+    try {
+      const user = await User.findOne({
+        where: { id: userId, isActive: true },
+        transaction
+      });
 
-    if (!user) {
-      throw new Error('User not found');
+      if (!user) {
+        await transaction.rollback();
+        throw new Error('User not found');
+      }
+
+      // Don't allow role or email updates through regular update
+      delete updateData.role;
+      delete updateData.email;
+      delete updateData.isActive;
+
+      // Update base user if there's data
+      if (Object.keys(updateData).length > 0) {
+        await user.update(updateData, { transaction });
+      }
+
+      // Update role-specific profile if provided
+      if (Object.keys(profileData).length > 0) {
+        if (user.role === 'technician') {
+          await Technician.update(profileData, {
+            where: { userId: user.id },
+            transaction
+          });
+        } else if (user.role === 'branch_manager') {
+          await BranchManager.update(profileData, {
+            where: { userId: user.id },
+            transaction
+          });
+        } else if (user.role === 'maintenance_executive') {
+          await MaintenanceExecutive.update(profileData, {
+            where: { userId: user.id },
+            transaction
+          });
+        }
+      }
+
+      await transaction.commit();
+
+      // Fetch updated user with profile
+      return await this.getUserById(userId);
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
     }
-
-    // Don't allow role or email updates through regular update
-    delete updateData.role;
-    delete updateData.email;
-    delete updateData.isActive;
-
-    await user.update(updateData);
-
-    const updatedUser = user.toJSON();
-    delete updatedUser.password;
-    return updatedUser;
   }
 
   /**
-   * Soft delete user by ID
+   * Soft delete user by ID 
    * @param {number} userId - User ID
    * @returns {Promise<Object>} Success message
    */
@@ -110,9 +232,9 @@ class UserService {
   }
 
   /**
-   * Get users by role
+   * Get users by role with profiles
    * @param {string} role - User role
-   * @returns {Promise<Array>} List of users
+   * @returns {Promise<Array>} List of users with profiles
    */
   async getUsersByRole(role) {
     return this.getAllUsers(role);


### PR DESCRIPTION
- Add Technician, BranchManager, and MaintenanceExecutive models
- Create database migrations for role-specific tables
- Implement one-to-one relationships between User and role profiles
- Update UserService to handle profile creation with transactions
- Update controllers to separate user data from profile data
- Add seeder for role profile demo data
- Update tests to match new error messages
- All 38 tests passing